### PR TITLE
Feature/aot 492 (and AOT-503)

### DIFF
--- a/pkg/executor/java_options.go
+++ b/pkg/executor/java_options.go
@@ -224,8 +224,8 @@ func (m *appDynamicsOptions) modifyArguments(context ArgumentsContext) []string 
 	// Two AppD controller clusters represent all OCP clusters. We need at least som unique app_name
 	openshiftCluster, exists := context.Environment("OPENSHIFT_CLUSTER")
 	if exists {
-		appDynamicsEnableClusterSufix, exists := context.Environment("APPDYNAMICS_ENABLE_CLUSTER_SUFIX")
-		if !exists || exists && strings.ToUpper(appDynamicsEnableClusterSufix) != "FALSE" {
+		appDynamicsEnableClusterSuffix, exists := context.Environment("APPDYNAMICS_ENABLE_CLUSTER_SUFFIX")
+		if !exists || exists && strings.ToUpper(appDynamicsEnableClusterSuffix) != "FALSE" {
 			agentAppName += "-" + openshiftCluster
 		}
 	}

--- a/pkg/executor/java_options.go
+++ b/pkg/executor/java_options.go
@@ -224,7 +224,10 @@ func (m *appDynamicsOptions) modifyArguments(context ArgumentsContext) []string 
 	// Two AppD controller clusters represent all OCP clusters. We need at least som unique app_name
 	openshiftCluster, exists := context.Environment("OPENSHIFT_CLUSTER")
 	if exists {
-		agentAppName += "-" + openshiftCluster
+		openshiftDisableSufix, exists := context.Environment("APPDYNAMICS_ENABLE_CLUSTER_SUFIX")
+		if !exists || exists && strings.ToUpper(openshiftDisableSufix) != "FALSE" {
+			agentAppName += "-" + openshiftCluster
+		}
 	}
 
 	agentTierName, exists := context.Environment("APPDYNAMICS_AGENT_TIER_NAME")

--- a/pkg/executor/java_options.go
+++ b/pkg/executor/java_options.go
@@ -224,8 +224,8 @@ func (m *appDynamicsOptions) modifyArguments(context ArgumentsContext) []string 
 	// Two AppD controller clusters represent all OCP clusters. We need at least som unique app_name
 	openshiftCluster, exists := context.Environment("OPENSHIFT_CLUSTER")
 	if exists {
-		openshiftEnableSufix, exists := context.Environment("APPDYNAMICS_ENABLE_CLUSTER_SUFIX")
-		if !exists || exists && strings.ToUpper(openshiftEnableSufix) != "FALSE" {
+		appDynamicsEnableClusterSufix, exists := context.Environment("APPDYNAMICS_ENABLE_CLUSTER_SUFIX")
+		if !exists || exists && strings.ToUpper(appDynamicsEnableClusterSufix) != "FALSE" {
 			agentAppName += "-" + openshiftCluster
 		}
 	}

--- a/pkg/executor/java_options.go
+++ b/pkg/executor/java_options.go
@@ -37,6 +37,7 @@ var Java8ArgumentsModificators = []ArgumentModificator{
 	&cpuCoreTuning{},
 	&memoryOptions{},
 	&metaspaceOptions{},
+	&heapDumpPath{},
 }
 
 //Java11ArgumentsModificators :
@@ -48,6 +49,7 @@ var Java11ArgumentsModificators = []ArgumentModificator{
 	&java11DiagnosticsOptions{},
 	&jolokiaOptions{},
 	&appDynamicsOptions{},
+	&heapDumpPath{},
 }
 
 type java11DiagnosticsOptions struct {
@@ -350,6 +352,27 @@ func (m *metaspaceOptions) modifyArguments(context ArgumentsContext) []string {
 	if limits.HasMemoryLimit() {
 		args = append([]string{fmt.Sprintf("-XX:MaxMetaspaceSize=%dm", limits.MemoryFractionInMB(fraction))}, args...)
 	}
+	return args
+}
+
+var heapdumppathArguments = []string{"-XX:HeapDumpPath"}
+
+type heapDumpPath struct {
+}
+
+func (m *heapDumpPath) shouldModifyArguments(context ArgumentsContext) bool {
+	return !containsArgument(context.Arguments, heapdumppathArguments...)
+}
+
+func (m *heapDumpPath) modifyArguments(context ArgumentsContext) []string {
+	javaHeapDumpPath, exists := context.Environment("JAVA_HEAPDUMP_PATH")
+	args := make([]string, 0)
+	if exists {
+		args = append([]string{fmt.Sprintf("-XX:HeapDumpPath=%s", javaHeapDumpPath)})
+	} else {
+		args = append([]string{"-XX:HeapDumpPath=/tmp"})
+	}
+	args = append(args, context.Arguments...)
 	return args
 }
 

--- a/pkg/executor/java_options.go
+++ b/pkg/executor/java_options.go
@@ -224,8 +224,8 @@ func (m *appDynamicsOptions) modifyArguments(context ArgumentsContext) []string 
 	// Two AppD controller clusters represent all OCP clusters. We need at least som unique app_name
 	openshiftCluster, exists := context.Environment("OPENSHIFT_CLUSTER")
 	if exists {
-		openshiftDisableSufix, exists := context.Environment("APPDYNAMICS_ENABLE_CLUSTER_SUFIX")
-		if !exists || exists && strings.ToUpper(openshiftDisableSufix) != "FALSE" {
+		openshiftEnableSufix, exists := context.Environment("APPDYNAMICS_ENABLE_CLUSTER_SUFIX")
+		if !exists || exists && strings.ToUpper(openshiftEnableSufix) != "FALSE" {
 			agentAppName += "-" + openshiftCluster
 		}
 	}

--- a/pkg/executor/java_options_test.go
+++ b/pkg/executor/java_options_test.go
@@ -141,6 +141,18 @@ func TestOptionsAppDynamics(t *testing.T) {
 	modifiedArgs = applyArguments(Java8ArgumentsModificators, ctx)
 	assert.NotContains(t, modifiedArgs, "-javaagent:/opt/appdynamics/javaagent.jar")
 	assert.NotContains(t, modifiedArgs, "-Dappdynamics")
+
+	env["ENABLE_APPDYNAMICS"] = "true"
+	env["APPDYNAMICS_ENABLE_CLUSTER_SUFIX"] = "false"
+	ctx = createTestContext(env)
+	modifiedArgs = applyArguments(Java8ArgumentsModificators, ctx)
+	assert.Contains(t, modifiedArgs, "-Dappdynamics.agent.applicationName=mynamespace")
+
+	env["ENABLE_APPDYNAMICS"] = "true"
+	env["APPDYNAMICS_ENABLE_CLUSTER_SUFIX"] = "this_is_default"
+	ctx = createTestContext(env)
+	modifiedArgs = applyArguments(Java8ArgumentsModificators, ctx)
+	assert.Contains(t, modifiedArgs, "-Dappdynamics.agent.applicationName=mynamespace-test")
 }
 
 func TestReadingOfJavaOptionsInDescriptor(t *testing.T) {

--- a/pkg/executor/java_options_test.go
+++ b/pkg/executor/java_options_test.go
@@ -143,13 +143,13 @@ func TestOptionsAppDynamics(t *testing.T) {
 	assert.NotContains(t, modifiedArgs, "-Dappdynamics")
 
 	env["ENABLE_APPDYNAMICS"] = "true"
-	env["APPDYNAMICS_ENABLE_CLUSTER_SUFIX"] = "false"
+	env["APPDYNAMICS_ENABLE_CLUSTER_SUFFIX"] = "false"
 	ctx = createTestContext(env)
 	modifiedArgs = applyArguments(Java8ArgumentsModificators, ctx)
 	assert.Contains(t, modifiedArgs, "-Dappdynamics.agent.applicationName=mynamespace")
 
 	env["ENABLE_APPDYNAMICS"] = "true"
-	env["APPDYNAMICS_ENABLE_CLUSTER_SUFIX"] = "this_is_default"
+	env["APPDYNAMICS_ENABLE_CLUSTER_SUFFIX"] = "this_is_default"
 	ctx = createTestContext(env)
 	modifiedArgs = applyArguments(Java8ArgumentsModificators, ctx)
 	assert.Contains(t, modifiedArgs, "-Dappdynamics.agent.applicationName=mynamespace-test")


### PR DESCRIPTION
- Set HeapDumpPath defaults to /tmp. Override with JAVA_HEAP_DUMP_PATH
- Set -XX:+HeapDumpOnOutOfMemoryError by default. Kan be turned off with JAVA_HEAP_DUMP_ON_OUT_OF_MEMORY_ERROR
- Remove Cluster Sufix for application name in AppDynamics by setting APPDYNAMICS_ENABLE_CLUSTER_SUFIX to false. Defaults to true.  